### PR TITLE
gemspec: List files using Ruby, including fewer files

### DIFF
--- a/gserver.gemspec
+++ b/gserver.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = "Ruby"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = Dir["{lib,sample}/**/*.rb", "README.md", "LICENSE.txt"]
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This PR cleans up the files directive in the gemspec, dropping inessential files.

Skip executables, test_files directives.